### PR TITLE
Givermei frontdoorfix

### DIFF
--- a/scenarios/aca-internal/bicep/modules/06-front-door/modules/front-door.bicep
+++ b/scenarios/aca-internal/bicep/modules/06-front-door/modules/front-door.bicep
@@ -59,7 +59,7 @@ resource frontDoorOriginGroup 'Microsoft.Cdn/profiles/origingroups@2022-05-01-pr
       additionalLatencyInMilliseconds: 50
     }
     healthProbeSettings: {
-      probePath: '/health'
+      probePath: '/'
       probeRequestType: 'HEAD'
       probeProtocol: 'Https'
       probeIntervalInSeconds: 100

--- a/scenarios/shared/bicep/naming/naming.module.bicep
+++ b/scenarios/shared/bicep/naming/naming.module.bicep
@@ -69,6 +69,7 @@ var resourceNames = {
   vmJumpBox: replace(namingBaseNoWorkloadName, resourceTypeToken, naming.resourceTypeAbbreviations.virtualMachine)
   vmJumpBoxNsg: '${naming.resourceTypeAbbreviations.networkSecurityGroup}-${replace(namingBaseNoWorkloadName, resourceTypeToken, naming.resourceTypeAbbreviations.virtualMachine)}'
   vmJumpBoxNic: '${naming.resourceTypeAbbreviations.networkInterface}-${replace(namingBaseNoWorkloadName, resourceTypeToken, naming.resourceTypeAbbreviations.virtualMachine)}'
+  frontDoor: replace(namingBase, resourceTypeToken, naming.resourceTypeAbbreviations.frontDoor)
 }
 
 output resourcesNames object = resourceNames


### PR DESCRIPTION
This PR contains fixes for the Azure Front Door deployment. 

1. naming conventions didn't have a resourcename for frontDoor, which gave a failure for deploy.front-door.bicep file line 54
2. changed AFD health probe to / as opposed to /health (preferable this value should be parameterized though)

Additional fixes that should be done (but not in this PR (yet?)). 

I created the base setup with deployHelloWorldSample set to false
I manually created a sampleapp (this was needed for fqdn input param for AFD)

I needed to also execute 

az network vnet subnet update \
    --name snet-pep \
    --vnet-name myvnetname \
    --resource-group myspokergname \
    --disable-private-link-service-network-policies yes

for the private link service creation for AFD. 

