### PR TITLE
Fix: Make client IP optional and add instructions for deploying app gateway in full deployment

### DIFF
--- a/scenarios/aca-internal/terraform/README.md
+++ b/scenarios/aca-internal/terraform/README.md
@@ -140,6 +140,7 @@ The table below summurizes the avaialble parameters and the possible values that
    | `spokeApplicationGatewaySubnetAddressPrefix` | CIDR of the spoke Application Gateway subnet. Must be a subset of the spoke CIDR ranges. | **10.1.3.0/24** | **10.101.3.0/24** |
    | `enableApplicationInsights` | Controls if Application Insights is deployed and configured. | **true** | **false** |
    | `deployHelloWorldSample` | Deploy a simple, sample application to the infrastructure. If you prefer to deploy the more comprehensive, Dapr-enabled sample app, this needs to be disabled | **true** | **false**, because you plan on deploying the Dapr-enabled application instead. |
+   | `clientIP` | If you'd like to deploy the architecture with Application Gateway without having to deploy Application Gateway separately, this should be set to the Public IP address of the machine executing the deployment | "" | 192.168.1.1 |
 
 
 #### Deploy

--- a/scenarios/aca-internal/terraform/README.md
+++ b/scenarios/aca-internal/terraform/README.md
@@ -145,6 +145,10 @@ The table below summurizes the avaialble parameters and the possible values that
 
 #### Deploy
 
+Before deploying, you need to decide how you would like to deploy the solution with Application Gateway. You have two options:
+- If you provide your client IP address, the Public IP address of the machine executing the Terraform deployment, it will be added to the Network ACL for the KeyVault used to house the Application Gateway certificate and it will allow you to proceed through the entire deployment. 
+- If you would like to keep the KeyVault fully private, you will need to comment out the Application Gateway module in the [main.tf](main.tf) and leave the clientIP value blank in your tfvars file. Follow the [instructions for deploying Application Gateway separately on your jump box](../terraform/modules/06-application-gateway/main.tf). 
+  
 #### Bash shell (i.e. inside WSL2 for windows 11, or any linux-based OS)
 ``` bash
 terraform init

--- a/scenarios/aca-internal/terraform/README.md
+++ b/scenarios/aca-internal/terraform/README.md
@@ -89,24 +89,6 @@ az storage container-rm create --storage-account $STORAGE_ACCOUNT_NAME --name $C
 
 ### Deploy the reference implementation
 
-#### Configure Terraform remote state
-
-To configure your Terraform deployment to use the newly provisioned storage account and container, edit the [`./providers.tf`](./providers.tf) file at lines 11-13 as below:
-
-```hcl
-  backend "azurerm" {
-    resource_group_name  = "<REPLACE with $RESOURCE_GROUP_NAME>"
-    storage_account_name = "<REPLACE with $STORAGE_ACCOUNT_NAME>"
-    container_name       = "tfstate"
-    key                  = "acalza/terraform.tfstate"
-  }
-```
-
-* `resource_group_name`: Name of the Azure Resource Group that the storage account resides in.
-* `storage_account_name`: Name of the Azure Storage Account to be used to hold remote state.
-* `container_name`: Name of the Azure Storage Account Blob Container to store remote state.
-* `key`: Path and filename for the remote state file to be placed in the Storage Account Container. If the state file does not exist in this path, Terraform will automatically generate one for you.
-
 #### Provide parameters required for deployment
 
 As you configured the backend remote state with your live Azure infrastructure resource values, you must also provide them for your deployment.
@@ -151,7 +133,11 @@ Before deploying, you need to decide how you would like to deploy the solution w
   
 #### Bash shell (i.e. inside WSL2 for windows 11, or any linux-based OS)
 ``` bash
-terraform init
+terraform init `
+    --backend-config=resource_group_name="tfstate" `
+    --backend-config=storage_account_name=<Your TF State Store Storage Account Name> `
+    --backend-config=container_name="tfstate" `
+    --backend-config=key="acalza/terraform.state"
 terraform plan --var-file terraform.tfvars -out tfplan
 terraform apply tfplan
 ```

--- a/scenarios/aca-internal/terraform/main.tf
+++ b/scenarios/aca-internal/terraform/main.tf
@@ -44,6 +44,7 @@ module "supportingServices" {
   spokePrivateEndpointSubnetId        = module.spoke.spokePrivateEndpointsSubnetId
   containerRegistryPullRoleAssignment = var.containerRegistryPullRoleAssignment
   keyVaultPullRoleAssignment          = var.keyVaultPullRoleAssignment
+  clientIP                            = var.clientIP
   vnetLinks = [
     {
       "name"                = module.spoke.spokeVNetName
@@ -97,13 +98,16 @@ module "helloWorldApp" {
   tags                                    = var.tags
 }
 
+
+# If you would like to deploy an Application Gateway and have provided your IP address for KeyVault access, leave this module uncommented
+# If you would like to keep your KeyVault private, comment out this module
 module "applicationGateway" {
   source                          = "./modules/06-application-gateway"
   workloadName                    = var.workloadName
   environment                     = var.environment
   location                        = var.location
   resourceGroupName               = module.spoke.spokeResourceGroupName
-  keyVaultId                      = module.supportingServices.keyVaultId
+  keyVaultName                    = module.supportingServices.keyVaultName
   appGatewayCertificateKeyName    = var.appGatewayCertificateKeyName
   appGatewayFQDN                  = var.appGatewayFQDN
   appGatewayPrimaryBackendEndFQDN = module.helloWorldApp.helloWorldAppFQDN
@@ -111,9 +115,4 @@ module "applicationGateway" {
   appGatewayLogAnalyticsId        = module.containerAppsEnvironment.logAnalyticsWorkspaceId
   appGatewayCertificatePath       = var.appGatewayCertificatePath
   tags                            = var.tags
-
-  # RBAC role should be assigned before creating a new secret (certificate appgw)
-  # moduleDependencies = [
-  #   module.supportingServices.keyVaultSecretsOfficerRoleAssignmentId
-  # ]
 }

--- a/scenarios/aca-internal/terraform/modules/01-hub/variables.tf
+++ b/scenarios/aca-internal/terraform/modules/01-hub/variables.tf
@@ -16,7 +16,7 @@ variable "environment" {
 
 variable "location" {
   type    = string
-  default = "eastus"
+  default = "northeurope"
 }
 
 variable "hubResourceGroupName" {}

--- a/scenarios/aca-internal/terraform/modules/02-spoke/variables.tf
+++ b/scenarios/aca-internal/terraform/modules/02-spoke/variables.tf
@@ -16,7 +16,7 @@ variable "environment" {
 
 variable "location" {
   type    = string
-  default = "eastus"
+  default = "northeurope"
 }
 
 variable "hubVnetId" {

--- a/scenarios/aca-internal/terraform/modules/03-supporting-services/outputs.tf
+++ b/scenarios/aca-internal/terraform/modules/03-supporting-services/outputs.tf
@@ -13,3 +13,7 @@ output "containerRegistryUserAssignedIdentityId" {
 output "keyVaultId" {
   value = module.keyVault.keyVaultId
 }
+
+output "keyVaultName" {
+  value = module.keyVault.keyVaultName
+}

--- a/scenarios/aca-internal/terraform/modules/04-container-apps-environment/variables.tf
+++ b/scenarios/aca-internal/terraform/modules/04-container-apps-environment/variables.tf
@@ -19,7 +19,7 @@ variable "environment" {
 
 variable "location" {
   type    = string
-  default = "eastus"
+  default = "northeurope"
 }
 
 variable "spokeVnetId" {

--- a/scenarios/aca-internal/terraform/modules/06-application-gateway/main.tf
+++ b/scenarios/aca-internal/terraform/modules/06-application-gateway/main.tf
@@ -21,21 +21,17 @@ resource "azurerm_user_assigned_identity" "appGatewayUserIdentity" {
 
 module "appGatewayAddCertificates" {
   source                                    = "../../../../shared/terraform/modules/application-gateway/certificate-config"
-  keyVaultId                                = var.keyVaultId
+  keyVaultName                              = var.keyVaultName
   resourceGroupName                         = var.resourceGroupName
   appGatewayCertificateKeyName              = var.appGatewayCertificateKeyName
   appGatewayCertificateData                 = local.appGatewayCertificate
   appGatewayUserAssignedIdentityPrincipalId = azurerm_user_assigned_identity.appGatewayUserIdentity.principal_id
-
-  # moduleDependencies = [
-  #   var.moduleDependencies
-  # ]
 }
 
 module "appGatewayConfiguration" {
   source                           = "../../../../shared/terraform/modules/application-gateway/gateway-config"
   appGatewayName                   = module.naming.resourceNames["applicationGateway"]
-  resourceGroupName                = var.resourceGroupName # module.naming.resourceNames["rgSpokeName"]
+  resourceGroupName                = var.resourceGroupName
   location                         = var.location
   diagnosticSettingName            = "agw-diagnostics"
   appGatewayFQDN                   = var.appGatewayFQDN

--- a/scenarios/aca-internal/terraform/modules/06-application-gateway/variables.tf
+++ b/scenarios/aca-internal/terraform/modules/06-application-gateway/variables.tf
@@ -18,6 +18,6 @@ variable "appGatewayLogAnalyticsId" {}
 
 variable "tags" {}
 
-variable "keyVaultId" {}
+variable "keyVaultName" {}
 
 variable "appGatewayCertificatePath" {}

--- a/scenarios/aca-internal/terraform/modules/06-front-door/variables.tf
+++ b/scenarios/aca-internal/terraform/modules/06-front-door/variables.tf
@@ -19,7 +19,7 @@ variable "environment" {
 
 variable "location" {
   type    = string
-  default = "eastus"
+  default = "northeurope"
 }
 
 variable "containerAppsEnvironmentId" {}

--- a/scenarios/aca-internal/terraform/providers.tf
+++ b/scenarios/aca-internal/terraform/providers.tf
@@ -13,15 +13,8 @@ terraform {
   }
   required_version = ">= 1.3.4"
 
-  backend "local" {
-
+  backend "azurerm" { 
   }
-  # backend "azurerm" { # todo
-  #   resource_group_name  = "tfstate"
-  #   storage_account_name = "tfstate2074974790"
-  #   container_name       = "tfstate"
-  #   key                  = "aca-lz/terraform.tfstate"
-  # }
 }
 
 provider "azurerm" {

--- a/scenarios/aca-internal/terraform/terraform.tfvars
+++ b/scenarios/aca-internal/terraform/terraform.tfvars
@@ -19,7 +19,7 @@ infraSubnetName                       = "snet-infra"
 privateEndpointsSubnetAddressPrefix   = "10.1.2.0/24"
 applicationGatewaySubnetAddressPrefix = "10.1.3.0/24"
 deployHelloWorldSample                = true
-clientIP                              = ""
+clientIP                              = "<Add your client IP here for use in KeyVault access permissions>"
 securityRules = [
   {
     "name" : "Allow_Internal_AKS_Connection_Between_Nodes_And_Control_Plane_UDP",

--- a/scenarios/aca-internal/terraform/terraform.tfvars
+++ b/scenarios/aca-internal/terraform/terraform.tfvars
@@ -3,7 +3,6 @@ workloadName = "lzaaca"
 //The name of the environment (e.g. "dev", "test", "prod", "preprod", "staging", "uat", "dr", "qa"). Up to 8 characters long.
 environment                           = "dev"
 tags                                  = {}
-hubResourceGroupName                  = ""
 location                              = "northeurope"
 hubVnetAddressPrefixes                = ["10.0.0.0/16"]
 enableBastion                         = true
@@ -14,13 +13,13 @@ vmAdminPassword                       = "@Aa123456789" # change this to a strong
 vmLinuxSshAuthorizedKeys              = ""
 vmJumpboxOSType                       = "Linux"
 vmJumpBoxSubnetAddressPrefix          = "10.0.3.0/24"
-# spokeResourceGroupName                = "rg-lzaaca-spoke-dev-eus"
 spokeVnetAddressPrefixes              = ["10.1.0.0/22"]
 infraSubnetAddressPrefix              = "10.1.0.0/23"
 infraSubnetName                       = "snet-infra"
 privateEndpointsSubnetAddressPrefix   = "10.1.2.0/24"
 applicationGatewaySubnetAddressPrefix = "10.1.3.0/24"
 deployHelloWorldSample                = true
+clientIP                              = ""
 securityRules = [
   {
     "name" : "Allow_Internal_AKS_Connection_Between_Nodes_And_Control_Plane_UDP",
@@ -104,4 +103,3 @@ appInsightsName                     = "appInsightsAca"
 helloWorldContainerAppName          = "ca-hello-world"
 appGatewayCertificateKeyName        = "agwcert"
 appGatewayFQDN                      = "acahello.demoapp.com"
-# appGatewayPrimaryBackendEndFQDN     = "ca-hello-world.politecoast-62b8bed6.eastus.azurecontainerapps.io" # todo : this should be output of ACA app

--- a/scenarios/aca-internal/terraform/variables.tf
+++ b/scenarios/aca-internal/terraform/variables.tf
@@ -16,7 +16,7 @@ variable "environment" {
 
 variable "location" {
   type    = string
-  default = "eastus"
+  default = "northeurope"
 }
 
 variable "hubResourceGroupName" {

--- a/scenarios/aca-internal/terraform/variables.tf
+++ b/scenarios/aca-internal/terraform/variables.tf
@@ -135,3 +135,7 @@ variable "deployHelloWorldSample" {
   default = true
   type = bool
 }
+
+variable "clientIP" {
+  default = ""
+}

--- a/scenarios/shared/terraform/modules/aca-environment/variables.tf
+++ b/scenarios/shared/terraform/modules/aca-environment/variables.tf
@@ -4,7 +4,7 @@
 
 variable "location" {
   type    = string
-  default = "eastus"
+  default = "northeurope"
 }
 
 variable "environmentName" {

--- a/scenarios/shared/terraform/modules/application-gateway/certificate-config/main.tf
+++ b/scenarios/shared/terraform/modules/application-gateway/certificate-config/main.tf
@@ -3,15 +3,17 @@ data "azurerm_key_vault" "keyVault" {
   resource_group_name = var.resourceGroupName
 }
 
+resource "azurerm_role_assignment" "keyvaultSecretUserRoleAssignment" {
+  scope                = data.azurerm_key_vault.keyVault.id 
+  principal_id         = var.appGatewayUserAssignedIdentityPrincipalId
+  role_definition_name = "Key Vault Secrets User"
+}
+
 resource "azurerm_key_vault_secret" "sslCertSecret" {
+  depends_on = [ azurerm_role_assignment.keyvaultSecretUserRoleAssignment ]
   name         = var.appGatewayCertificateKeyName
   key_vault_id = data.azurerm_key_vault.keyVault.id
   value        = var.appGatewayCertificateData
   content_type = "application/x-pkcs12"
 }
 
-resource "azurerm_role_assignment" "keyvaultSecretUserRoleAssignment" {
-  scope                = data.azurerm_key_vault.keyVault.id # "/subscriptions/${data.azurerm_client_config.current.subscription_id}/${azurerm_key_vault_secret.sslCertSecret.id}" 
-  principal_id         = var.appGatewayUserAssignedIdentityPrincipalId
-  role_definition_name = "Key Vault Secrets User"
-}

--- a/scenarios/shared/terraform/modules/identity/managed-identity/variables.tf
+++ b/scenarios/shared/terraform/modules/identity/managed-identity/variables.tf
@@ -12,7 +12,7 @@ variable "resourceGroupName" {
 }
 
 variable "location" {
-  default = "eastus"
+  default = "northeurope"
   type    = string
 }
 

--- a/scenarios/shared/terraform/modules/keyvault/main.tf
+++ b/scenarios/shared/terraform/modules/keyvault/main.tf
@@ -8,7 +8,7 @@ resource "azurerm_key_vault" "keyvault" {
   tenant_id                       = data.azurerm_client_config.current.tenant_id
   soft_delete_retention_days      = 7
   purge_protection_enabled        = false
-  public_network_access_enabled   = true # todo false
+  public_network_access_enabled   = (var.clientIP == "" || var.clientIP == null)? false : true
   enable_rbac_authorization       = true
   enabled_for_template_deployment = true
   tags                            = var.tags
@@ -16,7 +16,7 @@ resource "azurerm_key_vault" "keyvault" {
   network_acls {
     default_action             = "Deny"
     bypass                     = "AzureServices"
-    ip_rules                   = [var.clientIP]
+    ip_rules                   = (var.clientIP == "" || var.clientIP == null)? null : [var.clientIP]
     virtual_network_subnet_ids = null
   }
 }

--- a/scenarios/shared/terraform/modules/monitoring/app-insights/variables.tf
+++ b/scenarios/shared/terraform/modules/monitoring/app-insights/variables.tf
@@ -12,7 +12,7 @@ variable "resourceGroupName" {
 }
 
 variable "location" {
-  default = "eastus"
+  default = "northeurope"
   type    = string
 }
 

--- a/scenarios/shared/terraform/modules/monitoring/log-analytics/variables.tf
+++ b/scenarios/shared/terraform/modules/monitoring/log-analytics/variables.tf
@@ -12,7 +12,7 @@ variable "resourceGroupName" {
 }
 
 variable "location" {
-  default = "eastus"
+  default = "northeurope"
   type    = string
 }
 

--- a/scenarios/shared/terraform/modules/naming/variables.tf
+++ b/scenarios/shared/terraform/modules/naming/variables.tf
@@ -100,7 +100,7 @@ variable "environment" {
 
 variable "location" {
   type    = string
-  default = "eastus"
+  default = "northeurope"
 }
 
 variable "uniqueId" {}

--- a/scenarios/shared/terraform/modules/networking/private-endpoints/variables.tf
+++ b/scenarios/shared/terraform/modules/networking/private-endpoints/variables.tf
@@ -9,7 +9,7 @@ variable "endpointName" {
 }
 
 variable "location" {
-  default = "eastus"
+  default = "northeurope"
   type    = string
 }
 

--- a/scenarios/shared/terraform/modules/networking/vnet/variables.tf
+++ b/scenarios/shared/terraform/modules/networking/vnet/variables.tf
@@ -9,7 +9,7 @@ variable "networkName" {
 }
 
 variable "location" {
-  default = "eastus"
+  default = "northeurope"
   type    = string
 }
 

--- a/scenarios/shared/terraform/modules/vms/variables.tf
+++ b/scenarios/shared/terraform/modules/vms/variables.tf
@@ -7,7 +7,7 @@ variable "nsgName" {
 }
 
 variable "location" {
-  default = "eastus"
+  default = "northeurope"
 }
 
 variable "tags" {


### PR DESCRIPTION
**Terraform implementation**
- Made client IP optional variable
- Added example of clientIP reference in terraform.tfvars file
- Added instructions for setting clientIP in readme
- Added options for app gateway deployment in the readme
- Updated default location on all variables to northeurope