### PR TITLE
Chore: Update Terraform version

### DIFF
--- a/scenarios/aca-internal/terraform/modules/01-hub/providers.tf
+++ b/scenarios/aca-internal/terraform/modules/01-hub/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.50.0"
+      version = "~> 3.71.0"
     }
   }
   required_version = ">= 1.3.4"

--- a/scenarios/aca-internal/terraform/modules/02-spoke/providers.tf
+++ b/scenarios/aca-internal/terraform/modules/02-spoke/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.50.0"
+      version = "~> 3.71.0"
     }
   }
   required_version = ">= 1.3.4"

--- a/scenarios/aca-internal/terraform/modules/03-supporting-services/providers.tf
+++ b/scenarios/aca-internal/terraform/modules/03-supporting-services/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.50.0"
+      version = "~> 3.71.0"
     }
   }
   required_version = ">= 1.3.4"

--- a/scenarios/aca-internal/terraform/modules/04-container-apps-environment/providers.tf
+++ b/scenarios/aca-internal/terraform/modules/04-container-apps-environment/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.50.0"
+      version = "~> 3.71.0"
     }
   }
   required_version = ">= 1.3.4"

--- a/scenarios/aca-internal/terraform/modules/05-hello-world-sample-app/providers.tf
+++ b/scenarios/aca-internal/terraform/modules/05-hello-world-sample-app/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.50.0"
+      version = "~> 3.71.0"
     }
   }
   required_version = ">= 1.3.4"

--- a/scenarios/aca-internal/terraform/modules/06-application-gateway/providers.tf
+++ b/scenarios/aca-internal/terraform/modules/06-application-gateway/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.50.0"
+      version = "~> 3.71.0"
     }
   }
   required_version = ">= 1.3.4"

--- a/scenarios/aca-internal/terraform/providers.tf
+++ b/scenarios/aca-internal/terraform/providers.tf
@@ -3,12 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.50.0"
-    }
-
-    http = {
-      source  = "hashicorp/http"
-      version = "3.3.0"
+      version = "~> 3.71.0"
     }
   }
   required_version = ">= 1.3.4"

--- a/scenarios/shared/terraform/modules/application-gateway/main.tf
+++ b/scenarios/shared/terraform/modules/application-gateway/main.tf
@@ -130,26 +130,3 @@ resource "azurerm_application_gateway" "appGateway" {
 
   zones = var.makeZoneRedundant == true? var.zones: []
 }
-
-resource "azurerm_monitor_diagnostic_setting" "name" {
-  name                       = var.diagnosticSettingName
-  target_resource_id         = azurerm_application_gateway.appGateway.id
-  log_analytics_workspace_id = var.appGatewayLogAnalyticsId
-
-  enabled_log {
-    category_group = "allLogs"
-    retention_policy {
-      enabled = true
-      days    = 0
-    }
-  }
-
-  metric {
-    category = "AllMetrics"
-    enabled  = true
-    retention_policy {
-      enabled = false
-      days    = 0
-    }
-  }
-}

--- a/scenarios/shared/terraform/modules/application-gateway/outputs.tf
+++ b/scenarios/shared/terraform/modules/application-gateway/outputs.tf
@@ -1,0 +1,3 @@
+output "applicationGatewayId" {
+    value = azurerm_application_gateway.appGateway.id
+}

--- a/scenarios/shared/terraform/modules/diagnostics/main.tf
+++ b/scenarios/shared/terraform/modules/diagnostics/main.tf
@@ -22,7 +22,6 @@ resource "azurerm_monitor_diagnostic_setting" "rule" {
 
       retention_policy {
         enabled = true
-        days    = 30
       }
     }
   }
@@ -37,7 +36,6 @@ resource "azurerm_monitor_diagnostic_setting" "rule" {
 
       retention_policy {
         enabled = true
-        days    = 30
       }
     }
   }

--- a/scenarios/shared/terraform/modules/diagnostics/providers.tf
+++ b/scenarios/shared/terraform/modules/diagnostics/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.50.0"
+      version = "~> 3.71.0"
     }
   }
   required_version = ">= 1.3.4"

--- a/scenarios/shared/terraform/modules/identity/managed-identity/provider.tf
+++ b/scenarios/shared/terraform/modules/identity/managed-identity/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.48.0"
+      version = "~> 3.71.0"
     }
   }
   required_version = ">= 1.3.4"


### PR DESCRIPTION
- Updated Terraform version from 3.50 to 3.71
- Microsoft deprecated support for retention policies on diagnostic settings so I removed the days setting for the retention policy in the module 
- Removed duplicate diagnostic setting deployment in App Gateway