### PR TITLE
fix private endpoints issue for kv and acr in terraform demo

### DIFF
--- a/scenarios/shared/terraform/modules/acr/main.tf
+++ b/scenarios/shared/terraform/modules/acr/main.tf
@@ -28,6 +28,7 @@ module "containerRegistryPrivateEndpoints" {
   privateLinkId     = azurerm_container_registry.acr.id
   privateDnsZoneIds = [module.containerRegistryPrivateZones.privateDnsZoneId]
   subResourceNames  = local.subResourceNames
+  location          = var.location
   tags              = var.tags
 }
 

--- a/scenarios/shared/terraform/modules/keyvault/main.tf
+++ b/scenarios/shared/terraform/modules/keyvault/main.tf
@@ -41,6 +41,7 @@ module "keyVaultPrivateEndpoints" {
   privateLinkId     = azurerm_key_vault.keyvault.id
   privateDnsZoneIds = [module.keyVaultPrivateZones.privateDnsZoneId]
   subResourceNames  = local.subResourceNames
+  location          = var.location
   tags              = var.tags
 }
 


### PR DESCRIPTION
for fixing the issue, https://github.com/Azure/aca-landing-zone-accelerator/issues/140

just need to pass the location value to kv and acr private endpoint. otherwise, they always pick the default value.

 i've tested on my side. it looks good now, as shown in the picture attached.  

![Screenshot 2024-05-16 202022](https://github.com/Azure/aca-landing-zone-accelerator/assets/17306003/e127b133-884a-4cb3-822b-b0a3d23e68e2)