### PR TITLE
comment out workload profile spec on aca deployment

### DIFF
--- a/scenarios/aca-internal/terraform/modules/01-hub/README.md
+++ b/scenarios/aca-internal/terraform/modules/01-hub/README.md
@@ -53,7 +53,7 @@ backend "azurerm" {
    :stop_sign: Update this to your desired region.
 
    ```Terraform
-   location = "northeurope" # or any location that suits your needs
+   location="eastus" # or any location that suits your needs
    vmAdminPassword = "<Strong Password>"
    ```
 

--- a/scenarios/aca-internal/terraform/modules/05-hello-world-sample-app/main.tf
+++ b/scenarios/aca-internal/terraform/modules/05-hello-world-sample-app/main.tf
@@ -4,7 +4,7 @@ resource "azurerm_container_app" "helloWorld" {
   resource_group_name          = var.resourceGroupName
   container_app_environment_id = var.containerAppsEnvironmentId
   tags                         = var.tags
-  workload_profile_name        = var.workloadProfileName
+  # workload_profile_name        = var.workloadProfileName
 
   identity {
     type         = "UserAssigned"


### PR DESCRIPTION
commenting out workload profile because specifying workload profiles doesnt work when using consumption only and the default aca environment we are using uses only consumption